### PR TITLE
Add IEEE formatter

### DIFF
--- a/src/python_autocite/__main__.py
+++ b/src/python_autocite/__main__.py
@@ -5,6 +5,7 @@ from bs4 import BeautifulSoup
 from python_autocite.lib.citation import Citation
 from python_autocite.formatter.apa import APAFormatter
 from python_autocite.formatter.bibtex import BibTexFormatter
+from python_autocite.formatter.ieee import IEEEFormatter
 from python_autocite.lib.datafinder import Datafinder
 from python_autocite.lib.capture import PageCapture
 import datetime
@@ -77,7 +78,7 @@ def main():
             '--format',
             required=False,
             default='apa',
-            help="Output citation format. 'bibtex' and 'apa' are supported. Defaults to 'apa'."
+            help="Output citation format. 'bibtex', 'apa', and 'ieee' are supported. Defaults to 'apa'."
             )
 
     args = parser.parse_args()
@@ -90,6 +91,8 @@ def main():
         formatter = APAFormatter()
     elif args.format.lower() == 'bibtex':
         formatter = BibTexFormatter()
+    elif args.format.lower() == 'ieee':
+        formatter = IEEEFormatter()
     else:
         print("Unsupported/unrecognized formatter. Run autocite --help to see supported formatters.")
         sys.exit(1)

--- a/src/python_autocite/formatter/ieee.py
+++ b/src/python_autocite/formatter/ieee.py
@@ -59,7 +59,7 @@ class IEEEFormatter(CitationFormatter):
             return self.AUTHOR_UNKNOWN
 
         authors.sort()
-        if (len(authors > 6)):
+        if (len(authors) > 6):
             formatted_authors = self._get_author_format(authors) % authors[0]
         else:
             formatted_authors = self._get_author_format(authors) % tuple(authors)

--- a/src/python_autocite/formatter/ieee.py
+++ b/src/python_autocite/formatter/ieee.py
@@ -1,0 +1,76 @@
+from python_autocite.formatter import CitationFormatter
+
+
+class IEEEFormatter(CitationFormatter):
+
+    def format(self, citation):
+        # Format strings with and without publishign date
+        format = "%s, \"%s,\" %s. [Online]. Available: %s."
+        format_no_date = "%s, \"%s.\" [Online]. Available: %s."
+
+        # Optional trailing format string for access date
+        format_access = "[Accessed %s]"
+        
+        if self._format_pubdate(citation.publication_date) == self.PUBDATE_UNKNOWN:
+
+            output = format_no_date % (
+                self._assemble_authors(citation.authors),
+                citation.title,
+                citation.url,
+                )        
+        else:
+            output = format % (
+                self._assemble_authors(citation.authors),
+                citation.title,
+                self._format_pubdate(citation.publication_date),
+                citation.url,
+                ) 
+
+        if self._format_accessdate(citation.access_date) == self.ACCESSDATE_UNKNOWN:
+            output = output + (format_access % self._format_accessdate(citation.access_date))
+
+        return output
+    
+    def _get_author_format(self, authors):
+        if (len(authors) == 0):
+            return self.AUTHOR_UNKNOWN
+        elif (len(authors) == 1):
+            return "%s"
+        elif (len(authors) == 2):
+            return "%s, & %s"
+        else:
+            format_string = "%s, " * (len(authors)-1)
+            return format_string + "& %s"
+
+    def _assemble_authors(self, authors):
+
+        formatted_names = set()
+
+        for a in authors:
+            first_last = a.split()
+            if (len(first_last) > 1):
+                # This pulls the last name and first initial
+                formatted_names.add(first_last[1] + ", " + first_last[0][0] + ".")
+
+        authors = list(formatted_names)
+        if (len(authors) < 1):
+            return self.AUTHOR_UNKNOWN
+
+        authors.sort()
+
+        formatted_authors = self._get_author_format(authors) % tuple(authors)
+        return formatted_authors
+
+    def _format_pubdate(self, date):
+        if (date is not None):
+            return date.strftime("%Y, %B %d")
+        else:
+            return self.PUBDATE_UNKNOWN
+
+    def _format_accessdate(self, date):
+        if (date is not None):
+            return date.strftime("%B %d, %Y")
+        else:
+            return self.ACCESSDATE_UNKNOWN
+
+

--- a/src/python_autocite/formatter/ieee.py
+++ b/src/python_autocite/formatter/ieee.py
@@ -37,10 +37,12 @@ class IEEEFormatter(CitationFormatter):
         elif (len(authors) == 1):
             return "%s"
         elif (len(authors) == 2):
-            return "%s, & %s"
+            return "%s, and %s"
+        elif (len(authors) > 6):
+            return "%s et al."
         else:
             format_string = "%s, " * (len(authors)-1)
-            return format_string + "& %s"
+            return format_string + "and %s"
 
     def _assemble_authors(self, authors):
 
@@ -50,15 +52,18 @@ class IEEEFormatter(CitationFormatter):
             first_last = a.split()
             if (len(first_last) > 1):
                 # This pulls the last name and first initial
-                formatted_names.add(first_last[1] + ", " + first_last[0][0] + ".")
+                formatted_names.add(first_last[0][0] + ", " + first_last[1])
 
         authors = list(formatted_names)
         if (len(authors) < 1):
             return self.AUTHOR_UNKNOWN
 
         authors.sort()
-
-        formatted_authors = self._get_author_format(authors) % tuple(authors)
+        if (len(authors > 6)):
+            formatted_authors = self._get_author_format(authors) % authors[0]
+        else:
+            formatted_authors = self._get_author_format(authors) % tuple(authors)
+            
         return formatted_authors
 
     def _format_pubdate(self, date):


### PR DESCRIPTION
This adds a basic IEEE formatter. It formats dates as "YYYY, [Word month] day" and formats authors as "[first initial] [last name]" for each author, or [first author initial and last name] et al" if >6 authors, per [reference guide].(https://comunidad.udistrital.edu.co/redesdeingenieria/files/2013/04/Referencias-IEEE.pdf)

It also adds `ieee` as a valid option to the `--format` command lie argument